### PR TITLE
Feature/window display flags

### DIFF
--- a/gsplus/src/CMakeLists.txt
+++ b/gsplus/src/CMakeLists.txt
@@ -43,6 +43,12 @@ if(NOT DEFINED GSPLUS_VERSION OR GSPLUS_VERSION STREQUAL "")
 endif()
 message(STATUS "GSplus: version ${GSPLUS_VERSION}")
 
+# Make the version string available to all targets defined below (the app's
+# window title/startup log in sdl_driver.c and the status line in sim65816.c).
+# Scope to C only: Swift rejects valued -D defines (it has present/absent flags).
+add_compile_definitions(
+    "$<$<COMPILE_LANGUAGE:C>:GSPLUS_VERSION_STR=\"${GSPLUS_VERSION}\">")
+
 # ----------------------------------------------------------------------------
 # The platform-independent core sources.
 # This is exactly the OBJECTS list from the old `ldvars` file -- the files that
@@ -228,10 +234,6 @@ add_executable(gsplus-sdl
     sdl_snd_driver.c
 )
 target_link_libraries(gsplus-sdl PRIVATE gsplus_core_sdl SDL3::SDL3)
-
-# Expose the version string to the app (window title / startup log).
-target_compile_definitions(gsplus-sdl PRIVATE
-    "GSPLUS_VERSION_STR=\"${GSPLUS_VERSION}\"")
 
 if(WIN32)
     # The core uses Winsock (scc serial-over-TCP) and Win32 multimedia timers,

--- a/gsplus/src/CMakeLists.txt
+++ b/gsplus/src/CMakeLists.txt
@@ -248,22 +248,38 @@ if(APPLE)
     # Tell CMake to drop the icon into the bundle's Contents/Resources.
     set_source_files_properties(${GSPLUS_SDL_ICON} PROPERTIES
         MACOSX_PACKAGE_LOCATION Resources)
+    # The app is just "GSplus". We keep the bundle FOLDER named GSplus-SDL.app so
+    # it doesn't collide with the native Swift app's GSplus.app in the same build
+    # dir; the executable inside and the app's display name are plain "GSplus".
     set_target_properties(gsplus-sdl PROPERTIES
         MACOSX_BUNDLE TRUE
         OUTPUT_NAME "GSplus-SDL"
-        MACOSX_BUNDLE_BUNDLE_NAME "GSplus-SDL"
-        MACOSX_BUNDLE_GUI_IDENTIFIER "com.gsplus.sdl"
+        MACOSX_BUNDLE_BUNDLE_NAME "GSplus"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "com.gsplus.GSplus"
         MACOSX_BUNDLE_BUNDLE_VERSION "${GSPLUS_VERSION}"
         MACOSX_BUNDLE_SHORT_VERSION_STRING "${GSPLUS_VERSION}"
         MACOSX_BUNDLE_ICON_FILE "kegsicon.icns"
         # Look for bundled dylibs next to the executable in ../Frameworks.
         INSTALL_RPATH "@executable_path/../Frameworks")
+
+    # CMake names the bundle folder and the executable both after OUTPUT_NAME, so
+    # to get GSplus-SDL.app/Contents/MacOS/GSplus we rename the executable after
+    # the build and point CFBundleExecutable at it.
+    add_custom_command(TARGET gsplus-sdl POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E rename
+            "$<TARGET_FILE:gsplus-sdl>" "$<TARGET_FILE_DIR:gsplus-sdl>/GSplus"
+        COMMAND /usr/libexec/PlistBuddy -c "Set :CFBundleExecutable GSplus"
+            "$<TARGET_BUNDLE_CONTENT_DIR:gsplus-sdl>/Info.plist"
+        COMMENT "Renaming bundle executable to GSplus"
+        VERBATIM)
 endif()
 
 if(NOT APPLE)
-    # Linux/Windows: find a co-located SDL3 shared library next to the binary
-    # ($ORIGIN is the runtime path of the executable on ELF systems).
-    set_target_properties(gsplus-sdl PROPERTIES INSTALL_RPATH "$ORIGIN")
+    # The binary is just "gsplus" (no -sdl). $ORIGIN lets it find a co-located
+    # SDL3 shared library at runtime (ELF).
+    set_target_properties(gsplus-sdl PROPERTIES
+        OUTPUT_NAME "gsplus"
+        INSTALL_RPATH "$ORIGIN")
 endif()
 
 if(WIN32)

--- a/gsplus/src/config.c
+++ b/gsplus/src/config.c
@@ -152,6 +152,18 @@ extern Cfg_menu g_cfg_main_menu[];
 #define KNMP(a)		&a, #a, 0
 #define KNM(a)		&a, #a
 
+/* SDL display options not present in upstream KEGS. Registered in the Video
+ * Settings menu below, so they're settable via the config panel, config.kegs,
+ * and the command line (KEGS style, e.g. "-g_fullscreen 1"). The SDL driver
+ * reads them; the X11 and native macOS drivers ignore them. (Window size and
+ * position use KEGS's existing g_mainwin_width/height/xpos/ypos.) */
+int	g_fullscreen = 0;	/* start in fullscreen (F11 toggles at runtime) */
+int	g_borderless = 0;	/* no window title bar / border */
+int	g_noaspect = 0;		/* stretch to fill instead of keeping the ratio */
+int	g_highdpi = 1;		/* request a high-DPI backing surface */
+int	g_novsync = 0;		/* disable vsync */
+int	g_nohwaccel = 0;	/* force the software renderer */
+
 Cfg_menu g_cfg_disk_menu[] = {
 { "Disk Configuration", g_cfg_disk_menu, 0, 0, CFGTYPE_MENU },
 { "s5d1 = ", 0, 0, 0, CFGTYPE_DISK + 0x5000 },
@@ -338,6 +350,13 @@ Cfg_menu g_cfg_video_menu[] = {
 	"8,Off (Update video every 8 lines)",
 		KNMP(g_video_line_update_interval), CFGTYPE_INT },
 { "Dump text screen to file", (void *)cfg_text_screen_dump, 0, 0, CFGTYPE_FUNC},
+{ "", 0, 0, 0, 0 },
+{ "Start Fullscreen (SDL),0,No,1,Yes", KNMP(g_fullscreen), CFGTYPE_INT },
+{ "Borderless Window (SDL),0,No,1,Yes", KNMP(g_borderless), CFGTYPE_INT },
+{ "Ignore Aspect Ratio (SDL),0,No,1,Yes", KNMP(g_noaspect), CFGTYPE_INT },
+{ "High DPI (SDL),0,No,1,Yes", KNMP(g_highdpi), CFGTYPE_INT },
+{ "Disable VSync (SDL),0,No,1,Yes", KNMP(g_novsync), CFGTYPE_INT },
+{ "Force Software Renderer (SDL),0,No,1,Yes", KNMP(g_nohwaccel), CFGTYPE_INT },
 { "", 0, 0, 0, 0 },
 { "Back to Main Config", g_cfg_main_menu, 0, 0, CFGTYPE_MENU },
 { 0, 0, 0, 0, 0 },

--- a/gsplus/src/config.c
+++ b/gsplus/src/config.c
@@ -351,12 +351,14 @@ Cfg_menu g_cfg_video_menu[] = {
 		KNMP(g_video_line_update_interval), CFGTYPE_INT },
 { "Dump text screen to file", (void *)cfg_text_screen_dump, 0, 0, CFGTYPE_FUNC},
 { "", 0, 0, 0, 0 },
-{ "Start Fullscreen (SDL),0,No,1,Yes", KNMP(g_fullscreen), CFGTYPE_INT },
-{ "Borderless Window (SDL),0,No,1,Yes", KNMP(g_borderless), CFGTYPE_INT },
-{ "Ignore Aspect Ratio (SDL),0,No,1,Yes", KNMP(g_noaspect), CFGTYPE_INT },
-{ "High DPI (SDL),0,No,1,Yes", KNMP(g_highdpi), CFGTYPE_INT },
-{ "Disable VSync (SDL),0,No,1,Yes", KNMP(g_novsync), CFGTYPE_INT },
-{ "Force Software Renderer (SDL),0,No,1,Yes", KNMP(g_nohwaccel), CFGTYPE_INT },
+/* name_str (the CLI flag / config.kegs key) has no "g_" prefix -- that's just
+ * our C convention for globals, not something users should type. */
+{ "Start Fullscreen (SDL),0,No,1,Yes", &g_fullscreen, "fullscreen", 0, CFGTYPE_INT },
+{ "Borderless Window (SDL),0,No,1,Yes", &g_borderless, "borderless", 0, CFGTYPE_INT },
+{ "Ignore Aspect Ratio (SDL),0,No,1,Yes", &g_noaspect, "noaspect", 0, CFGTYPE_INT },
+{ "High DPI (SDL),0,No,1,Yes", &g_highdpi, "highdpi", 0, CFGTYPE_INT },
+{ "Disable VSync (SDL),0,No,1,Yes", &g_novsync, "novsync", 0, CFGTYPE_INT },
+{ "Force Software Renderer (SDL),0,No,1,Yes", &g_nohwaccel, "nohwaccel", 0, CFGTYPE_INT },
 { "", 0, 0, 0, 0 },
 { "Back to Main Config", g_cfg_main_menu, 0, 0, CFGTYPE_MENU },
 { 0, 0, 0, 0, 0 },
@@ -534,6 +536,13 @@ config_add_argv_override(const char *str1, const char *str2)
 	const char *equal_ptr;
 	char	*str;
 	int	ret, pos, len;
+
+	// A flag with no following value (e.g. "-foo" at the end of argv, or an
+	// unknown option) arrives with str2 == NULL. Treat it as an empty value so
+	// strlen() below doesn't dereference NULL and crash.
+	if(str2 == 0) {
+		str2 = "";
+	}
 
 	// Handle things like "rom=rompath" and "rom", "rompath"
 	// Look through str1, see if there is '=', if so ignore str2

--- a/gsplus/src/sdl_driver.c
+++ b/gsplus/src/sdl_driver.c
@@ -55,6 +55,14 @@ typedef struct {
 
 static Window_info g_mainwin_info;
 
+/* Window/display options, defined in config.c and settable via the command line
+ * (e.g. "-fullscreen 1") or config.kegs. */
+extern int g_fullscreen, g_borderless, g_noaspect, g_highdpi;
+extern int g_novsync, g_nohwaccel;
+extern int g_mainwin_xpos, g_mainwin_ypos;	/* window position (KEGS config vars) */
+
+static int g_is_fullscreen = 0;		/* current fullscreen state (F11 toggles) */
+
 /* Version string (set by the build from the git tag; see CMakeLists.txt). */
 #ifndef GSPLUS_VERSION_STR
 # define GSPLUS_VERSION_STR	"dev"
@@ -117,24 +125,38 @@ sdl_video_init(void)
 
 	video_update_scale(km, w, h, 1);
 
+	/* Window flags and size from the configured display options. */
+	SDL_WindowFlags flags = SDL_WINDOW_RESIZABLE;
+	if(g_highdpi)    { flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY; }
+	if(g_borderless) { flags |= SDL_WINDOW_BORDERLESS; }
+	if(g_fullscreen) { flags |= SDL_WINDOW_FULLSCREEN; g_is_fullscreen = 1; }
+
 	g_mainwin_info.window = SDL_CreateWindow("GSplus " GSPLUS_VERSION_STR,
-				w, h,
-				SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY);
+				w, h, flags);
 	if(!g_mainwin_info.window) {
 		printf("SDL_CreateWindow failed: %s\n", SDL_GetError());
 		exit(1);
 	}
-	g_mainwin_info.renderer = SDL_CreateRenderer(g_mainwin_info.window, NULL);
+	if(!g_fullscreen) {
+		SDL_SetWindowPosition(g_mainwin_info.window,
+					g_mainwin_xpos, g_mainwin_ypos);
+	}
+
+	/* "-nohwaccel 1" forces the software renderer; otherwise SDL picks the best. */
+	g_mainwin_info.renderer = SDL_CreateRenderer(g_mainwin_info.window,
+				g_nohwaccel ? "software" : NULL);
 	if(!g_mainwin_info.renderer) {
 		printf("SDL_CreateRenderer failed: %s\n", SDL_GetError());
 		exit(1);
 	}
+	SDL_SetRenderVSync(g_mainwin_info.renderer, g_novsync ? 0 : 1);
 	printf("SDL renderer backend: %s\n",
 		SDL_GetRendererName(g_mainwin_info.renderer));
 
-	/* Preserve the IIgs aspect ratio, letterboxing as the window resizes. */
+	/* Keep the IIgs aspect ratio (letterbox) unless -noaspect stretches to fill. */
 	SDL_SetRenderLogicalPresentation(g_mainwin_info.renderer, w, h,
-					SDL_LOGICAL_PRESENTATION_LETTERBOX);
+		g_noaspect ? SDL_LOGICAL_PRESENTATION_STRETCH
+			   : SDL_LOGICAL_PRESENTATION_LETTERBOX);
 
 	sdl_create_texture(&g_mainwin_info, w, h);
 
@@ -313,9 +335,20 @@ sdl_poll_events(void)
 			video_set_x_refresh_needed(g_mainwin_info.kimage_ptr, 1);
 			break;
 		case SDL_EVENT_KEY_DOWN:
+			/* F11 toggles fullscreen (gsplus convention); not sent to the IIgs. */
+			if(ev.key.scancode == SDL_SCANCODE_F11) {
+				if(!ev.key.repeat) {
+					g_is_fullscreen = !g_is_fullscreen;
+					SDL_SetWindowFullscreen(win->window, g_is_fullscreen);
+				}
+				break;
+			}
 			sdl_handle_key(win, ev.key.scancode, 0, ev.key.repeat);
 			break;
 		case SDL_EVENT_KEY_UP:
+			if(ev.key.scancode == SDL_SCANCODE_F11) {
+				break;
+			}
 			sdl_handle_key(win, ev.key.scancode, 1, 0);
 			break;
 		case SDL_EVENT_MOUSE_MOTION:

--- a/gsplus/src/sim65816.c
+++ b/gsplus/src/sim65816.c
@@ -14,6 +14,12 @@
 #include "defc.h"
 #undef INCLUDE_RCSID_C
 
+/* GSplus version for the status line, set by the build from the git tag (see
+ * CMakeLists.txt). Fallback for non-CMake (Makefile) builds. */
+#ifndef GSPLUS_VERSION_STR
+# define GSPLUS_VERSION_STR	"1.38.0"
+#endif
+
 double g_dtime_sleep = 0;
 double g_dtime_in_sleep = 0;
 extern char *g_argv0_path;
@@ -1523,9 +1529,9 @@ update_60hz(dword64 dfcyc, double dtime_now)
 
 		draw_iwm_status(2, status_buf);
 
-		snprintf(status_buf, sizeof(status_buf), " KEGS v%-6s       "
+		snprintf(status_buf, sizeof(status_buf), " GSplus %-6s      "
 			"Press F4 for Config Menu    %s %s",
-			g_kegs_version_str, code_str1, code_str2);
+			GSPLUS_VERSION_STR, code_str1, code_str2);
 		video_update_status_line(3, status_buf);
 
 		g_status_refresh_needed = 1;


### PR DESCRIPTION
This restores a lot of the gsplus display flags for fullscreen, positioning, etc.  It uses KEGS style flags right now `-fullscreen 1`, but I may revisit and go back to something more modern or both.  🤷 