### PR TITLE
SDL: fix no audio on macOS and stutter from queue clears

### DIFF
--- a/gsplus/src/sdl_snd_driver.c
+++ b/gsplus/src/sdl_snd_driver.c
@@ -61,14 +61,17 @@ sdl_send_audio(byte *ptr, int size)
 	int	max_queued;
 
 	if(g_sdl_audio_stream) {
-		/* Keep latency bounded: if the emulator runs ahead of real time
-		 * (e.g. fast-forward) the queue grows without limit, so drop the
-		 * backlog once it exceeds ~0.5s of stereo S16 (rate*4 bytes/sec). */
+		/* SDL's audio thread plays from this queue on its own schedule,
+		 * decoupled from our main-loop pushes -- so the queue must stay
+		 * non-empty to avoid underruns (which sound like stutter). Keep
+		 * latency bounded WITHOUT emptying it: if we're already more than
+		 * ~0.5s of stereo S16 (rate*4 bytes/sec) ahead of playback, drop
+		 * these new samples rather than SDL_ClearAudioStream()ing the whole
+		 * backlog -- clearing leaves the buffer empty and causes a gap. */
 		max_queued = g_preferred_rate * 2;
-		if(SDL_GetAudioStreamQueued(g_sdl_audio_stream) > max_queued) {
-			SDL_ClearAudioStream(g_sdl_audio_stream);
+		if(SDL_GetAudioStreamQueued(g_sdl_audio_stream) <= max_queued) {
+			SDL_PutAudioStreamData(g_sdl_audio_stream, ptr, size);
 		}
-		SDL_PutAudioStreamData(g_sdl_audio_stream, ptr, size);
 	}
 
 	/* MUST be >= 0: the core's reliable_buf_write() calls exit(1) otherwise. */

--- a/gsplus/src/sound.c
+++ b/gsplus/src/sound.c
@@ -30,7 +30,8 @@ extern dword64 g_last_vbl_dfcyc;
 int	g_queued_samps = 0;
 int	g_queued_nonsamps = 0;
 
-#if defined(HPUX) || defined(__linux__) || defined(_WIN32) || defined(MAC)
+#if defined(HPUX) || defined(__linux__) || defined(_WIN32) || defined(MAC) || \
+		defined(SDL_AUDIO)
 int	g_audio_enable = -1;
 #else
 int	g_audio_enable = 0;		/* Not supported: default to off */


### PR DESCRIPTION
Two separate audio bugs in the SDL build:

1. No sound on macOS. g_audio_enable defaults to -1 (enabled) only when HPUX/__linux__/_WIN32/MAC is defined. Linux and Windows get this from compiler-defined __linux__/_WIN32, but the macOS SDL build defines none of them (it deliberately omits -DMAC, and there is no __APPLE__ check), so g_audio_enable stayed 0 and snddrv_init() bailed before ever opening a device. Add defined(SDL_AUDIO) so any SDL build enables audio.

2. Stutter (heard on Windows). When the queue exceeded the ~0.5s latency cap, sdl_send_audio() called SDL_ClearAudioStream(), emptying the whole buffer. SDL's audio thread plays from that queue on its own schedule, so draining it to empty causes an underrun/gap every time the emulator runs slightly ahead -- consistent stutter. Bound latency without emptying the queue: drop the new samples when already >0.5s ahead instead of clearing.