### PR TITLE
Add screenshot capture to the SDL driver (Shift+F12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 gsplus/GSplus.app/
 gsplus/src/build/
 config.kegs
+gsplus_screenshot_*.png
 
 # Local Claude Code tooling
 .agents/

--- a/gsplus/src/CMakeLists.txt
+++ b/gsplus/src/CMakeLists.txt
@@ -233,6 +233,7 @@ target_compile_options(gsplus_core_sdl PRIVATE -Wall)
 add_executable(gsplus-sdl
     sdl_driver.c
     sdl_snd_driver.c
+    png_write.c
 )
 target_link_libraries(gsplus-sdl PRIVATE gsplus_core_sdl SDL3::SDL3)
 

--- a/gsplus/src/config.c
+++ b/gsplus/src/config.c
@@ -163,6 +163,7 @@ int	g_noaspect = 0;		/* stretch to fill instead of keeping the ratio */
 int	g_highdpi = 1;		/* request a high-DPI backing surface */
 int	g_nohwaccel = 0;	/* force the software renderer */
 int	g_scanline_simulator = 0; /* CRT scanline overlay intensity, 0-100 (0=off) */
+char	*g_cfg_ssdir = "";	/* screenshot output dir ("" = current dir) */
 
 Cfg_menu g_cfg_disk_menu[] = {
 { "Disk Configuration", g_cfg_disk_menu, 0, 0, CFGTYPE_MENU },
@@ -359,6 +360,7 @@ Cfg_menu g_cfg_video_menu[] = {
 { "High DPI (SDL),0,No,1,Yes", &g_highdpi, "highdpi", 0, CFGTYPE_INT },
 { "Force Software Renderer (SDL),0,No,1,Yes", &g_nohwaccel, "nohwaccel", 0, CFGTYPE_INT },
 { "Scanline Simulator 0-100 (SDL)", &g_scanline_simulator, "scanline", 0, CFGTYPE_INT },
+{ "Screenshot Directory (SDL)", &g_cfg_ssdir, "ssdir", 0, CFGTYPE_STR },
 { "", 0, 0, 0, 0 },
 { "Back to Main Config", g_cfg_main_menu, 0, 0, CFGTYPE_MENU },
 { 0, 0, 0, 0, 0 },

--- a/gsplus/src/png_write.c
+++ b/gsplus/src/png_write.c
@@ -1,0 +1,234 @@
+/**********************************************************************/
+/*                    GSplus - Apple //gs Emulator                    */
+/*                    Based on KEGS by Kent Dickey                    */
+/*      This code is covered by the GNU GPL v3                        */
+/**********************************************************************/
+
+/* Minimal, dependency-free PNG writer.
+ *
+ * GSplus deliberately links no PNG/zlib library for screenshots, so this file
+ * emits a complete, valid PNG entirely by hand. The one trick is that PNG's
+ * IDAT data is a zlib stream, which normally implies DEFLATE compression -- but
+ * DEFLATE permits *stored* (uncompressed) blocks (BTYPE=00). We use only those,
+ * so no compressor is needed. The output is larger than a compressed PNG but is
+ * read correctly by every PNG decoder. We still must compute the two checksums
+ * the format requires: CRC-32 over each chunk and Adler-32 over the zlib data.
+ *
+ * write_png_rgba() takes 8-bit RGBA, top-to-bottom, tightly packed (no padding).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "defc.h"
+#include "protos_sdl.h"
+
+/* ---- CRC-32 (PNG chunk checksum, IEEE 802.3 polynomial 0xEDB88320) ------- */
+
+static unsigned long g_png_crc_table[256];
+static int g_png_crc_table_done = 0;
+
+static void
+png_crc_table_init(void)
+{
+	unsigned long c;
+	int n, k;
+
+	for(n = 0; n < 256; n++) {
+		c = (unsigned long)n;
+		for(k = 0; k < 8; k++) {
+			c = (c & 1) ? (0xedb88320UL ^ (c >> 1)) : (c >> 1);
+		}
+		g_png_crc_table[n] = c;
+	}
+	g_png_crc_table_done = 1;
+}
+
+/* Continue a running CRC-32 over `buf`; pass 0xffffffff as the seed. */
+static unsigned long
+png_crc_update(unsigned long c, const unsigned char *buf, size_t len)
+{
+	size_t i;
+
+	if(!g_png_crc_table_done) {
+		png_crc_table_init();
+	}
+	for(i = 0; i < len; i++) {
+		c = g_png_crc_table[(c ^ buf[i]) & 0xff] ^ (c >> 8);
+	}
+	return c;
+}
+
+/* ---- chunk emission ------------------------------------------------------ */
+
+static void
+png_put_be32(unsigned char *p, unsigned long v)
+{
+	p[0] = (unsigned char)(v >> 24);
+	p[1] = (unsigned char)(v >> 16);
+	p[2] = (unsigned char)(v >> 8);
+	p[3] = (unsigned char)(v);
+}
+
+/* Write one PNG chunk: length, 4-char type, data, then CRC over type+data. */
+static int
+png_write_chunk(FILE *f, const char *type, const unsigned char *data,
+		size_t len)
+{
+	unsigned char hdr[8];
+	unsigned char crcbuf[4];
+	unsigned long crc;
+
+	png_put_be32(hdr, (unsigned long)len);
+	memcpy(hdr + 4, type, 4);
+	if(fwrite(hdr, 1, 8, f) != 8) {
+		return -1;
+	}
+	if(len && fwrite(data, 1, len, f) != len) {
+		return -1;
+	}
+	/* CRC covers the type field and the data, but not the length. */
+	crc = png_crc_update(0xffffffffUL, (const unsigned char *)type, 4);
+	crc = png_crc_update(crc, data, len) ^ 0xffffffffUL;
+	png_put_be32(crcbuf, crc);
+	if(fwrite(crcbuf, 1, 4, f) != 4) {
+		return -1;
+	}
+	return 0;
+}
+
+/* ---- zlib wrapper using only stored (uncompressed) DEFLATE blocks -------- */
+
+/* Build a zlib stream around `raw`/`raw_len` made entirely of stored blocks.
+ * Returns a malloc'd buffer (caller frees) and sets *out_len, or NULL on OOM. */
+static unsigned char *
+png_zlib_store(const unsigned char *raw, size_t raw_len, size_t *out_len)
+{
+	const size_t MAXBLK = 65535;		/* stored-block length is 16-bit */
+	size_t nblocks, cap, pos, off;
+	unsigned char *out;
+	unsigned long adler, s1, s2;
+	size_t i;
+
+	nblocks = (raw_len + MAXBLK - 1) / MAXBLK;
+	if(nblocks == 0) {
+		nblocks = 1;			/* one empty final block */
+	}
+	/* 2 zlib header + per block (1 BFINAL/BTYPE + 2 LEN + 2 NLEN) + data
+	 * + 4 Adler-32. */
+	cap = 2 + nblocks * 5 + raw_len + 4;
+	out = malloc(cap);
+	if(!out) {
+		return NULL;
+	}
+
+	pos = 0;
+	out[pos++] = 0x78;			/* CMF: deflate, 32K window */
+	out[pos++] = 0x01;			/* FLG: (0x7801 % 31 == 0) */
+
+	off = 0;
+	do {
+		size_t blk = raw_len - off;
+		int final;
+		if(blk > MAXBLK) {
+			blk = MAXBLK;
+		}
+		final = (off + blk >= raw_len);
+		out[pos++] = final ? 1 : 0;	/* BFINAL bit, BTYPE=00 (stored) */
+		out[pos++] = (unsigned char)(blk & 0xff);
+		out[pos++] = (unsigned char)((blk >> 8) & 0xff);
+		out[pos++] = (unsigned char)(~blk & 0xff);	/* NLEN = ~LEN */
+		out[pos++] = (unsigned char)((~blk >> 8) & 0xff);
+		if(blk) {
+			memcpy(out + pos, raw + off, blk);
+			pos += blk;
+		}
+		off += blk;
+	} while(off < raw_len);
+
+	/* Adler-32 of the uncompressed data, stored big-endian. */
+	s1 = 1;
+	s2 = 0;
+	for(i = 0; i < raw_len; i++) {
+		s1 = (s1 + raw[i]) % 65521;
+		s2 = (s2 + s1) % 65521;
+	}
+	adler = (s2 << 16) | s1;
+	png_put_be32(out + pos, adler);
+	pos += 4;
+
+	*out_len = pos;
+	return out;
+}
+
+/* ---- public entry point -------------------------------------------------- */
+
+/* Write `rgba` (w*h pixels, 8-bit RGBA, top-to-bottom, no row padding) to a
+ * PNG at `path`. Returns 0 on success, non-zero on failure. */
+int
+write_png_rgba(const char *path, const unsigned char *rgba, int w, int h)
+{
+	static const unsigned char sig[8] =
+		{ 137, 80, 78, 71, 13, 10, 26, 10 };
+	unsigned char ihdr[13];
+	unsigned char *raw, *zlib;
+	size_t rawlen, zlen, rowbytes;
+	FILE	*f;
+	int	y, rc;
+
+	if(!rgba || w <= 0 || h <= 0) {
+		return -1;
+	}
+
+	/* Filtered raw scanlines: each row is a 0x00 filter byte (None) followed
+	 * by w*4 RGBA bytes. */
+	rowbytes = (size_t)w * 4;
+	rawlen = (size_t)h * (rowbytes + 1);
+	raw = malloc(rawlen);
+	if(!raw) {
+		return -1;
+	}
+	for(y = 0; y < h; y++) {
+		unsigned char *dst = raw + (size_t)y * (rowbytes + 1);
+		*dst++ = 0x00;			/* filter type: None */
+		memcpy(dst, rgba + (size_t)y * rowbytes, rowbytes);
+	}
+
+	zlib = png_zlib_store(raw, rawlen, &zlen);
+	free(raw);
+	if(!zlib) {
+		return -1;
+	}
+
+	f = fopen(path, "wb");
+	if(!f) {
+		free(zlib);
+		return -1;
+	}
+
+	rc = 0;
+	if(fwrite(sig, 1, 8, f) != 8) {
+		rc = -1;
+	}
+
+	/* IHDR: width, height, bit depth 8, colour type 6 (RGBA), default
+	 * compression/filter/interlace. */
+	png_put_be32(ihdr + 0, (unsigned long)w);
+	png_put_be32(ihdr + 4, (unsigned long)h);
+	ihdr[8] = 8;				/* bit depth */
+	ihdr[9] = 6;				/* colour type: truecolour+alpha */
+	ihdr[10] = 0;				/* compression method */
+	ihdr[11] = 0;				/* filter method */
+	ihdr[12] = 0;				/* interlace: none */
+
+	if(!rc) { rc = png_write_chunk(f, "IHDR", ihdr, sizeof(ihdr)); }
+	if(!rc) { rc = png_write_chunk(f, "IDAT", zlib, zlen); }
+	if(!rc) { rc = png_write_chunk(f, "IEND", NULL, 0); }
+
+	free(zlib);
+	if(fclose(f) != 0) {
+		rc = -1;
+	}
+	return rc;
+}

--- a/gsplus/src/protos_sdl.h
+++ b/gsplus/src/protos_sdl.h
@@ -15,4 +15,8 @@ void	sdl_snd_init(word32 *shmaddr);
 int	sdl_send_audio(byte *ptr, int size);
 void	sdl_snd_shutdown(void);
 
+/* png_write.c */
+int	write_png_rgba(const char *path, const unsigned char *rgba,
+			int w, int h);
+
 #endif /* GSPLUS_PROTOS_SDL_H */

--- a/gsplus/src/sdl_driver.c
+++ b/gsplus/src/sdl_driver.c
@@ -22,6 +22,7 @@
  */
 
 #include <SDL3/SDL.h>
+#include <time.h>
 
 #include "defc.h"
 #include "protos_sdl.h"
@@ -64,9 +65,11 @@ extern int g_fullscreen, g_borderless, g_noaspect, g_highdpi;
 extern int g_nohwaccel;
 extern int g_scanline_simulator;	/* CRT scanline overlay intensity, 0-100 */
 extern int g_mainwin_xpos, g_mainwin_ypos;	/* window position (KEGS config vars) */
+extern char *g_cfg_ssdir;		/* screenshot output dir ("" = current dir) */
 
 static int g_is_fullscreen = 0;		/* current fullscreen state (F11 toggles) */
 static int g_scanline_saved = 50;	/* intensity to restore when toggled back on */
+static int g_screenshot_requested = 0;	/* set by Shift+F12, serviced at frame end */
 
 /* Version string (set by the build from the git tag; see CMakeLists.txt). */
 #ifndef GSPLUS_VERSION_STR
@@ -192,7 +195,7 @@ sdl_video_init(void)
 	if(g_borderless) { flags |= SDL_WINDOW_BORDERLESS; }
 	if(g_fullscreen) { flags |= SDL_WINDOW_FULLSCREEN; g_is_fullscreen = 1; }
 
-	g_mainwin_info.window = SDL_CreateWindow("GSplus " GSPLUS_VERSION_STR,
+	g_mainwin_info.window = SDL_CreateWindow("GSplus",
 				w, h, flags);
 	if(!g_mainwin_info.window) {
 		printf("SDL_CreateWindow failed: %s\n", SDL_GetError());
@@ -422,6 +425,15 @@ sdl_poll_events(void)
 			}
 			break;
 		case SDL_EVENT_KEY_DOWN:
+			/* Shift+F12 saves a screenshot (gsplus convention); it is not
+			 * sent to the IIgs. Plain F12 still reaches the emulator. */
+			if(ev.key.scancode == SDL_SCANCODE_F12 &&
+					(SDL_GetModState() & SDL_KMOD_SHIFT)) {
+				if(!ev.key.repeat) {
+					g_screenshot_requested = 1;
+				}
+				break;
+			}
 			/* F11 toggles fullscreen; Shift+F11 toggles scanlines (gsplus
 			 * convention). Neither is sent to the IIgs. */
 			if(ev.key.scancode == SDL_SCANCODE_F11) {
@@ -447,6 +459,12 @@ sdl_poll_events(void)
 			if(ev.key.scancode == SDL_SCANCODE_F11) {
 				break;
 			}
+			/* Swallow the matching Shift+F12 release so the IIgs never
+			 * sees a stray F12 key-up from a screenshot combo. */
+			if(ev.key.scancode == SDL_SCANCODE_F12 &&
+					(SDL_GetModState() & SDL_KMOD_SHIFT)) {
+				break;
+			}
 			sdl_handle_key(win, ev.key.scancode, 1, 0);
 			break;
 		case SDL_EVENT_MOUSE_MOTION:
@@ -470,6 +488,89 @@ sdl_poll_events(void)
 		default:
 			break;
 		}
+	}
+}
+
+/* Build "[<ssdir>/]gsplus_screenshot_YYYYMMDD_HHMMSS.png" into buf. With no
+ * ssdir configured the file lands in the current working directory. */
+static void
+sdl_build_screenshot_path(char *buf, size_t buflen)
+{
+	char	fname[64];
+	time_t	now;
+	struct tm *tmv;
+
+	now = time(NULL);
+	tmv = localtime(&now);
+	strftime(fname, sizeof(fname),
+			"gsplus_screenshot_%Y%m%d_%H%M%S.png", tmv);
+
+	if(g_cfg_ssdir && g_cfg_ssdir[0]) {
+		size_t len = strlen(g_cfg_ssdir);
+		const char *sep = (g_cfg_ssdir[len - 1] == '/') ? "" : "/";
+		snprintf(buf, buflen, "%s%s%s", g_cfg_ssdir, sep, fname);
+	} else {
+		snprintf(buf, buflen, "%s", fname);
+	}
+}
+
+/* Grab the currently-rendered frame (post-scaling, including any scanline
+ * overlay and letterbox borders) and write it to a PNG. Called after the frame
+ * is drawn but before SDL_RenderPresent, so the back buffer is still valid. */
+static void
+sdl_save_screenshot(Window_info *win)
+{
+	SDL_Surface *shot, *conv;
+	unsigned char *packed;
+	char	path[1100];
+	size_t	rowbytes;
+	int	w, h, y, rc;
+
+	shot = SDL_RenderReadPixels(win->renderer, NULL);
+	if(!shot) {
+		printf("Screenshot failed: SDL_RenderReadPixels: %s\n",
+			SDL_GetError());
+		return;
+	}
+	/* Normalise to byte-order RGBA, which is what write_png_rgba() expects. */
+	conv = SDL_ConvertSurface(shot, SDL_PIXELFORMAT_RGBA32);
+	SDL_DestroySurface(shot);
+	if(!conv) {
+		printf("Screenshot failed: SDL_ConvertSurface: %s\n",
+			SDL_GetError());
+		return;
+	}
+
+	/* SDL surfaces may pad rows (pitch >= w*4); pack them tightly. */
+	w = conv->w;
+	h = conv->h;
+	rowbytes = (size_t)w * 4;
+	packed = malloc(rowbytes * (size_t)h);
+	if(!packed) {
+		SDL_DestroySurface(conv);
+		return;
+	}
+	for(y = 0; y < h; y++) {
+		unsigned char *dst = packed + (size_t)y * rowbytes;
+		memcpy(dst, (unsigned char *)conv->pixels
+				+ (size_t)y * conv->pitch, rowbytes);
+		/* The renderer's back buffer can carry a non-opaque alpha, which
+		 * makes viewers composite the PNG over white and wash the colors
+		 * out. A screenshot is opaque, so force every alpha byte to 0xff. */
+		for(int x = 0; x < w; x++) {
+			dst[x * 4 + 3] = 0xff;
+		}
+	}
+	SDL_DestroySurface(conv);
+
+	sdl_build_screenshot_path(path, sizeof(path));
+	rc = write_png_rgba(path, packed, w, h);
+	free(packed);
+
+	if(rc) {
+		printf("Screenshot failed: could not write %s\n", path);
+	} else {
+		printf("Screenshot saved: %s (%dx%d)\n", path, w, h);
 	}
 }
 
@@ -532,6 +633,13 @@ sdl_update_display(Window_info *win)
 			sdl_fill_overlay(win, g_scanline_simulator);
 		}
 		SDL_RenderTexture(win->renderer, win->overlay, NULL, NULL);
+	}
+
+	/* Service a pending Shift+F12 capture now, while the just-drawn frame is
+	 * still in the back buffer (RenderPresent may invalidate it). */
+	if(g_screenshot_requested) {
+		sdl_save_screenshot(win);
+		g_screenshot_requested = 0;
 	}
 
 	SDL_RenderPresent(win->renderer);


### PR DESCRIPTION
Press Shift+F12 to save a PNG of the current frame. Plain F12 still passes through to the emulated IIgs; the release of the combo is swallowed so the IIgs never sees a stray F12 key-up.

The frame is grabbed with SDL_RenderReadPixels after drawing but before RenderPresent, so it captures exactly what is on screen (scaling, scanline overlay, letterbox borders). Every pixel's alpha is forced opaque, since the back buffer can carry a non-opaque alpha that otherwise makes viewers composite the PNG over white and wash the colors out.

PNGs are written by a new dependency-free encoder (png_write.c): no PNG/zlib library is linked. It emits the IDAT zlib stream using only stored (uncompressed) DEFLATE blocks, and computes the required CRC-32 (chunks) and Adler-32 (zlib) checksums by hand.

A new "ssdir" config option sets the output directory (CLI "-ssdir <dir>", config.kegs "ssdir = <dir>", and the Video Settings menu); empty means the current directory. Filenames are gsplus_screenshot_YYYYMMDD_HHMMSS.png, and those are gitignored so captures are not committed by accident.

Also drops the version number from the SDL window title ("GSplus" instead of "GSplus <version>").