### PR TITLE
Add cross-platform SDL_Gamepad joystick to the SDL build

### DIFF
--- a/gsplus/src/CMakeLists.txt
+++ b/gsplus/src/CMakeLists.txt
@@ -224,7 +224,10 @@ endif()
 # gsplus_core library because its .o files already have -DMAC baked in.
 add_library(gsplus_core_sdl STATIC ${GSPLUS_CORE_SOURCES})
 target_include_directories(gsplus_core_sdl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_definitions(gsplus_core_sdl PUBLIC SDL_AUDIO)
+# SDL_AUDIO routes sound through the SDL backend; SDL_INPUT compiles the native
+# joystick backends (IOKit/joydev/mmsystem) out of joystick_driver.c so the
+# SDL_Gamepad backend in sdl_driver.c provides joystick_init/update instead.
+target_compile_definitions(gsplus_core_sdl PUBLIC SDL_AUDIO SDL_INPUT)
 target_compile_options(gsplus_core_sdl PRIVATE -Wall)
 
 # The portable executable: SDL driver + SDL audio backend, linked against the

--- a/gsplus/src/joystick_driver.c
+++ b/gsplus/src/joystick_driver.c
@@ -10,11 +10,19 @@
 
 #include "defc.h"
 
-#ifdef __linux__
+/* For the SDL build the joystick backend lives in sdl_driver.c (SDL_Gamepad),
+ * so compile out all the native per-platform backends below and mark the
+ * routines as defined to skip the fallback stubs. The shared callback helpers
+ * at the bottom of this file stay -- they touch no platform/SDL APIs. */
+#ifdef SDL_INPUT
+# define JOYSTICK_DEFINED
+#endif
+
+#if defined(__linux__) && !defined(SDL_INPUT)
 # include <linux/joystick.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(SDL_INPUT)
 # include <windows.h>
 # include <mmsystem.h>
 #endif
@@ -37,7 +45,7 @@ int	g_joystick_callback_buttons = 0;
 int	g_joystick_callback_x = 32767;
 int	g_joystick_callback_y = 32767;
 
-#ifdef __linux__
+#if defined(__linux__) && !defined(SDL_INPUT)
 # define JOYSTICK_DEFINED
 void
 joystick_init()
@@ -121,7 +129,7 @@ joystick_update_buttons()
 }
 #endif /* LINUX */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(SDL_INPUT)
 # define JOYSTICK_DEFINED
 #undef JOYSTICK_DEFINED
 	// HACK: remove

--- a/gsplus/src/sdl_driver.c
+++ b/gsplus/src/sdl_driver.c
@@ -397,6 +397,113 @@ sdl_button_mask(int sdl_button)
 	return (1 << sdl_button) >> 1;
 }
 
+/* ----------------------------------------------------------------------- */
+/* Game controller (joystick / paddle) support.                            */
+/*                                                                          */
+/* The IIgs sees a 2-axis, 2-button analog joystick on the paddle inputs.   */
+/* We drive it from SDL3's high-level Gamepad API, which gives a standard    */
+/* layout (left stick + A/B) and a built-in mapping database across         */
+/* XInput/DirectInput/HID/Bluetooth pads. The core polls us via             */
+/* joystick_update() whenever a program reads the paddle trigger ($C070);   */
+/* we just sample current state, which SDL keeps fresh because              */
+/* sdl_poll_events() pumps the event queue every frame (and handles         */
+/* hotplug). These three entry points replace the native IOKit/joydev/      */
+/* mmsystem backends in joystick_driver.c, which is compiled out for the    */
+/* SDL build (see SDL_INPUT in CMakeLists.txt). The user still picks        */
+/* "Native Joystick 1" in the config menu (F4) to route paddles here.       */
+
+extern int g_joystick_native_type1;	/* paddles.c: -1 = no joystick present */
+extern int g_paddle_buttons;		/* paddles.c: bits 0,1 = buttons 0,1 */
+extern int g_paddle_val[4];		/* paddles.c: [0]=X [1]=Y, -32768..32767 */
+
+static SDL_Gamepad *g_sdl_gamepad = NULL;	/* the open controller, or NULL */
+
+/* Open the first connected controller SDL has a gamepad mapping for. */
+static void
+sdl_open_first_gamepad(void)
+{
+	SDL_JoystickID *ids;
+	int	count, i;
+
+	if(g_sdl_gamepad) {
+		return;				/* already have one */
+	}
+	ids = SDL_GetGamepads(&count);
+	if(!ids) {
+		return;
+	}
+	for(i = 0; i < count; i++) {
+		if(!SDL_IsGamepad(ids[i])) {
+			continue;
+		}
+		g_sdl_gamepad = SDL_OpenGamepad(ids[i]);
+		if(g_sdl_gamepad) {
+			g_joystick_native_type1 = 1;
+			printf("SDL gamepad opened: %s\n",
+				SDL_GetGamepadName(g_sdl_gamepad));
+			break;
+		}
+	}
+	SDL_free(ids);
+}
+
+/* Read the two face buttons into the low bits of g_paddle_buttons. */
+void
+joystick_update_buttons(void)
+{
+	int	buttons;
+
+	if(!g_sdl_gamepad) {
+		return;
+	}
+	buttons = 0;
+	if(SDL_GetGamepadButton(g_sdl_gamepad, SDL_GAMEPAD_BUTTON_SOUTH)) {
+		buttons |= 1;		/* button 0 (e.g. A) */
+	}
+	if(SDL_GetGamepadButton(g_sdl_gamepad, SDL_GAMEPAD_BUTTON_EAST)) {
+		buttons |= 2;		/* button 1 (e.g. B) */
+	}
+	g_paddle_buttons = (g_paddle_buttons & ~3) | buttons;
+}
+
+/* Sample axes + buttons into the paddle globals. Called from paddles.c. */
+void
+joystick_update(dword64 dfcyc)
+{
+	int	i;
+
+	/* Default: centered, both buttons up. 0xc keeps the unused upper
+	 * paddle buttons high, matching the native backends. */
+	for(i = 0; i < 4; i++) {
+		g_paddle_val[i] = 32767;
+	}
+	g_paddle_buttons = 0xc;
+
+	if(!g_sdl_gamepad) {
+		return;
+	}
+	/* SDL gamepad axes are already Sint16 (-32768..32767), exactly the
+	 * paddle range the core expects. */
+	g_paddle_val[0] = SDL_GetGamepadAxis(g_sdl_gamepad,
+						SDL_GAMEPAD_AXIS_LEFTX);
+	g_paddle_val[1] = SDL_GetGamepadAxis(g_sdl_gamepad,
+						SDL_GAMEPAD_AXIS_LEFTY);
+	joystick_update_buttons();
+	paddle_update_trigger_dcycs(dfcyc);
+}
+
+/* Called once from kegs_init() (before sdl_video_init's SDL_Init). */
+void
+joystick_init(void)
+{
+	g_joystick_native_type1 = -1;
+	if(!SDL_InitSubSystem(SDL_INIT_GAMEPAD)) {
+		printf("SDL_INIT_GAMEPAD failed: %s\n", SDL_GetError());
+		return;
+	}
+	sdl_open_first_gamepad();
+}
+
 static void
 sdl_poll_events(void)
 {
@@ -485,6 +592,22 @@ sdl_poll_events(void)
 			adb_update_mouse(win->kimage_ptr, mx, my,
 				(ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN) ? mask : 0,
 				mask & 7);
+			break;
+		case SDL_EVENT_GAMEPAD_ADDED:
+			/* A controller was plugged in; adopt it if we have none. */
+			sdl_open_first_gamepad();
+			break;
+		case SDL_EVENT_GAMEPAD_REMOVED:
+			/* If the pad we were using went away, drop it and try to
+			 * fall back to any other still-connected controller. */
+			if(g_sdl_gamepad &&
+					SDL_GetGamepadID(g_sdl_gamepad) ==
+							ev.gdevice.which) {
+				SDL_CloseGamepad(g_sdl_gamepad);
+				g_sdl_gamepad = NULL;
+				g_joystick_native_type1 = -1;
+				sdl_open_first_gamepad();
+			}
 			break;
 		default:
 			break;


### PR DESCRIPTION
The portable SDL build had no working joystick on macOS or Windows: the SDL core is compiled without -DMAC (so the IOKit backend is excluded) and the Windows mmsystem backend is #if 0'd, leaving both to fall through to no-op stubs. Only Linux worked, via the native /dev/js0 path that bypasses SDL entirely.

Add a single SDL3 Gamepad backend that works identically on all three platforms. A new SDL_INPUT compile define (on gsplus_core_sdl, alongside SDL_AUDIO) compiles the native IOKit/joydev/mmsystem backends out of joystick_driver.c, and sdl_driver.c provides joystick_init/update/ update_buttons via SDL_Gamepad -- keeping SDL code out of the core, the same split used for SDL audio.

The backend polls (left stick -> paddle X/Y, A/B -> buttons 0/1); SDL's Sint16 axes already match the -32768..32767 paddle range, and state stays fresh because sdl_poll_events() pumps the event queue each frame. Hotplug (connect/disconnect) is handled there too. The user selects "Native Joystick 1" in the config menu to route paddles to the controller.

Native MAC/Windows builds are unaffected (SDL_INPUT absent -> preprocessing identical).