### PR TITLE
Fix emulated clock on macOS SDL build

### DIFF
--- a/gsplus/src/clock.c
+++ b/gsplus/src/clock.c
@@ -218,10 +218,12 @@ update_cur_time()
 	secs = mktime(tm_ptr);
 
 	secs2 = secs2 - secs;		// this is the timezone offset
-#ifdef MAC
+#if defined(MAC) || defined(__APPLE__)
 	/* Mac OS X's mktime function modifies the tm_ptr passed in for */
 	/*  the CDT timezone and breaks this algorithm.  So on a Mac, we */
 	/*  will use the tm_ptr->gmtoff member to correct the time */
+	/* Note: the SDL build compiles the core without -DMAC, so guard on */
+	/*  __APPLE__ too to keep correct clock behavior on macOS. */
 	secs = secs + tm_ptr->tm_gmtoff;
 #else
 	secs = cur_time - secs2;


### PR DESCRIPTION
The SDL core is compiled without -DMAC (it behaves as a generic build), so update_cur_time() took the non-Mac timezone branch on macOS. That branch relies on an algorithm the KEGS author documented as broken on macOS, where mktime() mutates the passed-in tm_ptr. Result: the SDL build's emulated IIgs clock and ProDOS file timestamps could drift up to an hour vs. the native Cocoa app on the same machine.

Guard the Mac tm_gmtoff path on __APPLE__ as well as MAC so the correct behavior is selected regardless of which build compiles the core.