### PR TITLE
Fix case-sensitive filename matching on macOS SDL build

### DIFF
--- a/gsplus/src/config.c
+++ b/gsplus/src/config.c
@@ -114,7 +114,10 @@ int	g_cfg_curs_mousetext = 0;
 int	g_cfg_screen_changed = 0;
 byte	g_cfg_screen[24][80];
 
-#if defined(MAC) || defined(_WIN32)
+// Note: the SDL build compiles the core without -DMAC, so guard on
+//  __APPLE__ too to keep case-insensitive matching on macOS (default
+//  APFS/HFS+ volumes are case-insensitive).
+#if defined(MAC) || defined(__APPLE__) || defined(_WIN32)
 int	g_cfg_ignorecase = 1;		// Ignore case in filenames
 #else
 int	g_cfg_ignorecase = 0;


### PR DESCRIPTION
The SDL core is compiled without -DMAC (it behaves as a generic build), so g_cfg_ignorecase defaulted to 0 on macOS, making filename matching case-sensitive. macOS default volumes (APFS/HFS+) are case-insensitive, so the F4 config browser and disk-image matching could fail to find files whose case differs from what's on disk.

Guard the case-insensitive default on __APPLE__ as well as MAC so the SDL build matches the native Cocoa app's behavior on macOS.