### PR TITLE
Pass ⌘ key combos to the IIgs on macOS SDL build

### DIFF
--- a/gsplus/src/CMakeLists.txt
+++ b/gsplus/src/CMakeLists.txt
@@ -240,6 +240,13 @@ add_executable(gsplus-sdl
 )
 target_link_libraries(gsplus-sdl PRIVATE gsplus_core_sdl SDL3::SDL3)
 
+if(APPLE)
+    # macOS-only: retune SDL's default menu bar so ⌘ combos pass through to the
+    # emulated IIgs and GSplus quits on ⌥⌘Q. The Objective-C source needs Cocoa.
+    target_sources(gsplus-sdl PRIVATE sdl_mac_menu.m)
+    target_link_libraries(gsplus-sdl PRIVATE "-framework Cocoa")
+endif()
+
 if(WIN32)
     # The core uses Winsock (scc serial-over-TCP) and Win32 multimedia timers,
     # which the native Win build links explicitly. SDL3 links its own deps.

--- a/gsplus/src/protos_sdl.h
+++ b/gsplus/src/protos_sdl.h
@@ -19,4 +19,10 @@ void	sdl_snd_shutdown(void);
 int	write_png_rgba(const char *path, const unsigned char *rgba,
 			int w, int h);
 
+#ifdef __APPLE__
+/* sdl_mac_menu.m -- retune SDL's default macOS menu so ⌘ combos reach the
+ * IIgs and GSplus quits on ⌥⌘Q instead of ⌘Q. */
+void	sdl_mac_fix_menu(void);
+#endif
+
 #endif /* GSPLUS_PROTOS_SDL_H */

--- a/gsplus/src/sdl_driver.c
+++ b/gsplus/src/sdl_driver.c
@@ -462,6 +462,13 @@ sdl_video_init(void)
 	 * dirty rectangles again, leaving the texture black. The X11 and Win32
 	 * drivers do the same on window expose. */
 	video_set_x_refresh_needed(km, 1);
+
+#ifdef __APPLE__
+	/* SDL has now installed its default macOS menu bar. Strip the ⌘ shortcuts
+	 * off its items so combos like ⌘W/⌘Q reach the emulated IIgs (which uses
+	 * ⌘ as Open-Apple), and move GSplus's own Quit to ⌥⌘Q. */
+	sdl_mac_fix_menu();
+#endif
 }
 
 /* --------------------------------------------------------------------------

--- a/gsplus/src/sdl_mac_menu.m
+++ b/gsplus/src/sdl_mac_menu.m
@@ -1,0 +1,59 @@
+/**********************************************************************/
+/*                    GSplus - Apple //gs Emulator                    */
+/*                    Based on KEGS by Kent Dickey                    */
+/*      This code is covered by the GNU GPL v3                        */
+/**********************************************************************/
+
+/* macOS-only helper for the SDL3 build.
+ *
+ * SDL3 installs a default macOS menu bar (Apple / App / Window menus) whose
+ * items carry the usual Command-key equivalents: ⌘Q quits, ⌘W closes the
+ * window, ⌘H hides, ⌘M minimizes. AppKit's responder chain consumes those
+ * combos before SDL ever sees the keyDown, so the emulated IIgs -- which uses
+ * ⌘ as the Open-Apple key and expects to receive ⌘Q, ⌘W, etc. -- never gets
+ * them. That breaks any IIgs software bound to those combos.
+ *
+ * sdl_mac_fix_menu() strips the key equivalent from every menu item so all ⌘
+ * combos fall through to SDL (and on to the emulated ADB), then rebinds the
+ * Quit item alone to ⌥⌘Q (Option+Command+Q) -- a combo no IIgs software uses
+ * -- so there's still a keyboard way to quit GSplus itself.
+ */
+
+#import <Cocoa/Cocoa.h>
+
+/* Declared in protos_sdl.h for the C callers; that header pulls in defc.h
+ * types we don't want here, so we just restate the one prototype. */
+void	sdl_mac_fix_menu(void);
+
+static void
+gsplus_strip_key_equivalents(NSMenu *menu)
+{
+	for (NSMenuItem *item in menu.itemArray) {
+		if (item.action == @selector(terminate:)) {
+			/* Quit GSplus -> ⌥⌘Q, off-limits to IIgs software. */
+			item.keyEquivalent = @"q";
+			item.keyEquivalentModifierMask =
+				NSEventModifierFlagCommand |
+				NSEventModifierFlagOption;
+		} else {
+			/* Drop the shortcut so the ⌘ combo reaches the IIgs.
+			 * The item stays in the menu and is still clickable. */
+			item.keyEquivalent = @"";
+			item.keyEquivalentModifierMask = 0;
+		}
+		if (item.submenu) {
+			gsplus_strip_key_equivalents(item.submenu);
+		}
+	}
+}
+
+void
+sdl_mac_fix_menu(void)
+{
+	@autoreleasepool {
+		NSMenu *menu = [NSApp mainMenu];
+		if (menu) {
+			gsplus_strip_key_equivalents(menu);
+		}
+	}
+}


### PR DESCRIPTION
SDL3 installs a default macOS menu bar whose items carry the usual ⌘-shortcuts (⌘Q quit, ⌘W close, ⌘H hide, ⌘M minimize). AppKit consumes those keystrokes before SDL delivers them, so the emulated IIgs -- which uses ⌘ as Open-Apple and expects combos like ⌘W/⌘Q -- never sees them.

Add a macOS-only helper (sdl_mac_menu.m) that, after SDL builds its menu, strips the key equivalent off every menu item so all ⌘ combos fall through to the emulated ADB, and rebinds GSplus's own Quit to ⌥⌘Q -- a combo no IIgs software uses -- so there's still a keyboard way to quit.



I have to thank @ksherlock for this idea, though the [implementation was a bit different](https://github.com/digarok/gsplus-legacy-archive/blob/master/src/fix_mac_menu.m).  Thanks!