### PR TITLE
Fix VOC SHR shadowing for bank $E0 in fixup_ramwrt()

### DIFF
--- a/gsplus/src/moremem.c
+++ b/gsplus/src/moremem.c
@@ -530,6 +530,9 @@ fixup_ramwrt()
 		}
 
 		shadow = 0;
+		if(i) {
+			shadow = BANK_SHADOW;		// For VOC SHR in bank 0
+		}
 		if(ramwrt && (((g_c035_shadow_reg & 0x08) == 0) || i)) {
 			/* shr shadowing */
 			shadow = BANK_SHADOW2;


### PR DESCRIPTION
Upstream KEGS fix (Kent Dickey): writes to the $E0/6000-$9FFF SHR region were not being shadowed, breaking VOC SHR animations. Set shadow = BANK_SHADOW for bank $E0 (i==1) before the ramwrt check so this region shadows correctly.

Of course, you still have to enable VOC in the display menu. 😉 