### PR TITLE
Make CRT vignette configurable (g_crt_vignette, 0-100)

### DIFF
--- a/gsplus/src/config.c
+++ b/gsplus/src/config.c
@@ -170,7 +170,8 @@ int	g_nohwaccel = 0;	/* force the software renderer */
 int	g_scanline_simulator = 0; /* CRT scanline overlay intensity, 0-100 (0=off) */
 int	g_crt = 0;		/* curved CRT effect (curvature+mask+glow+vignette) */
 int	g_crt_curve = 2;	/* CRT screen curvature amount, 0-100 (0=flat) */
-int	g_crt_mask = 8;	/* CRT phosphor-mask strength, 0-100 (0=off, subtle) */
+int	g_crt_mask = 5;	/* CRT phosphor-mask strength, 0-100 (0=off, subtle) */
+int	g_crt_vignette = 5;	/* CRT corner darkening, 0-100 (0=off, flat brightness) */
 int	g_hblur = 0;		/* horizontal linear blur, 0-100 (0=off, sharp) */
 int	g_vblur = 0;		/* vertical linear blur, 0-100 (0=off, sharp) */
 int	g_hide_mouse = 1;	/* hide host cursor over the window / in fullscreen */
@@ -359,6 +360,7 @@ Cfg_menu g_cfg_video_menu[] = {
 #if !defined(MAC) && !defined(SDL_INPUT) && !defined(_WIN32)
 { "Force X-windows display depth", KNMP(g_force_depth), CFGTYPE_INT },
 #endif
+{ "GSplus Display Effects (SDL)", g_cfg_sdl_video_menu, 0, 0, CFGTYPE_MENU },
 { "Enable VOC,0,Disabled,1,Enabled", KNMP(g_voc_enable), CFGTYPE_INT },
 { "Default Main Window width", KNMP(g_mainwin_width), CFGTYPE_INT },
 { "Default Main Window height", KNMP(g_mainwin_height), CFGTYPE_INT },
@@ -369,7 +371,6 @@ Cfg_menu g_cfg_video_menu[] = {
 		KNMP(g_video_line_update_interval), CFGTYPE_INT },
 { "Dump text screen to file", (void *)cfg_text_screen_dump, 0, 0, CFGTYPE_FUNC},
 { "", 0, 0, 0, 0 },
-{ "Display Effects (SDL)", g_cfg_sdl_video_menu, 0, 0, CFGTYPE_MENU },
 { "", 0, 0, 0, 0 },
 { "Back to Main Config", g_cfg_main_menu, 0, 0, CFGTYPE_MENU },
 { 0, 0, 0, 0, 0 },
@@ -382,7 +383,7 @@ Cfg_menu g_cfg_video_menu[] = {
  * The name_str (the CLI flag / config.kegs key) has no "g_" prefix -- that's
  * just our C convention for globals, not something users should type. */
 Cfg_menu g_cfg_sdl_video_menu[] = {
-{ "Display Effects (SDL)", g_cfg_sdl_video_menu, 0, 0, CFGTYPE_MENU },
+{ "GSplus Display Effects (SDL)", g_cfg_sdl_video_menu, 0, 0, CFGTYPE_MENU },
 { "Fullscreen,0,No,1,Yes", &g_fullscreen, "fullscreen", 0, CFGTYPE_INT },
 { "Borderless Window (restart required),0,No,1,Yes", &g_borderless, "borderless", 0, CFGTYPE_INT },
 { "Ignore Aspect Ratio (restart required),0,No,1,Yes", &g_noaspect, "noaspect", 0, CFGTYPE_INT },
@@ -392,6 +393,7 @@ Cfg_menu g_cfg_sdl_video_menu[] = {
 { "CRT Effect (curve+mask+glow),0,Off,1,On", &g_crt, "crt", 0, CFGTYPE_INT },
 { "CRT Curvature 0-100", &g_crt_curve, "crtcurve", 0, CFGTYPE_INT },
 { "CRT Phosphor Mask 0-100", &g_crt_mask, "crtmask", 0, CFGTYPE_INT },
+{ "CRT Vignette 0-100", &g_crt_vignette, "crtvignette", 0, CFGTYPE_INT },
 { "Horizontal Blur 0-100", &g_hblur, "hblur", 0, CFGTYPE_INT },
 { "Vertical Blur 0-100", &g_vblur, "vblur", 0, CFGTYPE_INT },
 { "Hide Mouse Cursor,0,No,1,Yes", &g_hide_mouse, "hidemouse", 0, CFGTYPE_INT },
@@ -1100,10 +1102,10 @@ cfg_int_update(int *iptr, int new_val)
 
 	old_val = *iptr;
 	if((iptr == &g_scanline_simulator) || (iptr == &g_crt_curve) ||
-				(iptr == &g_crt_mask) || (iptr == &g_hblur) ||
-				(iptr == &g_vblur)) {
-		// Scanline intensity, CRT curvature, phosphor-mask strength and
-		// horizontal/vertical blur are
+				(iptr == &g_crt_mask) || (iptr == &g_crt_vignette) ||
+				(iptr == &g_hblur) || (iptr == &g_vblur)) {
+		// Scanline intensity, CRT curvature, phosphor-mask strength,
+		// vignette and horizontal/vertical blur are
 		// 0-100 percentages (0=off/flat, 100=max). Clamp here so they can't
 		// go negative or above 100 from any path: typed edits, +/- arrows,
 		// or a hand-edited config file.

--- a/gsplus/src/sdl_driver.c
+++ b/gsplus/src/sdl_driver.c
@@ -60,6 +60,7 @@ typedef struct {
 	int		crt_nverts;
 	int		crt_nidx;
 	int		crt_curve_for;		/* g_crt_curve the mesh was built for */
+	int		crt_vig_for;		/* g_crt_vignette the mesh was built for */
 	word32		*data;			/* dest buffer for video_out_data() */
 	int		active;
 	int		width_req;		/* current logical width  (pixels) */
@@ -77,6 +78,7 @@ extern int g_scanline_simulator;	/* CRT scanline overlay intensity, 0-100 */
 extern int g_crt;			/* curved CRT effect on/off */
 extern int g_crt_curve;			/* CRT screen curvature, 0-100 */
 extern int g_crt_mask;			/* CRT phosphor-mask strength, 0-100 */
+extern int g_crt_vignette;		/* CRT corner darkening, 0-100 */
 extern int g_hblur;			/* horizontal linear blur, 0-100 */
 extern int g_vblur;			/* vertical linear blur, 0-100 */
 extern int g_hide_mouse;		/* hide host cursor over window / in fullscreen */
@@ -94,7 +96,6 @@ static int g_screenshot_requested = 0;	/* set by Shift+F12, serviced at frame en
  * these bake the rest of the look so the user gets one "CRT Effect" toggle. */
 #define CRT_MESH_COLS	32		/* curvature mesh resolution (cells) */
 #define CRT_MESH_ROWS	24
-#define CRT_VIGNETTE	0.28f		/* corner darkening, 0..1 */
 #define CRT_MASK_MIN	60		/* off-channel level at full mask strength
 					 * (0-255); g_crt_mask scales 255 (off)
 					 * down toward this floor */
@@ -224,8 +225,8 @@ sdl_fill_mask(Window_info *win, int w, int h)
 static void
 sdl_build_crt_mesh(Window_info *win, int w, int h)
 {
-	int	i, j, nx, ny, n, idx;
-	float	curve, u, v, px, py, wx, wy, r2, vig;
+	int	i, j, nx, ny, n, idx, vig_strength;
+	float	curve, vignette, u, v, px, py, wx, wy, r2, vig;
 
 	nx = CRT_MESH_COLS + 1;
 	ny = CRT_MESH_ROWS + 1;
@@ -243,6 +244,12 @@ sdl_build_crt_mesh(Window_info *win, int w, int h)
 	/* 0-100 curvature knob -> a gentle 0..~0.30 distortion coefficient. */
 	curve = (float)g_crt_curve * 0.003f;
 
+	/* 0-100 vignette knob -> 0..1 corner-darkening amount (0 = flat). */
+	vig_strength = g_crt_vignette;
+	if(vig_strength < 0)   { vig_strength = 0; }
+	if(vig_strength > 100) { vig_strength = 100; }
+	vignette = (float)vig_strength * 0.01f;
+
 	n = 0;
 	for(j = 0; j < ny; j++) {
 		for(i = 0; i < nx; i++) {
@@ -259,7 +266,7 @@ sdl_build_crt_mesh(Window_info *win, int w, int h)
 			win->crt_verts[n].tex_coord.x = u;
 			win->crt_verts[n].tex_coord.y = v;
 			r2 = px * px + py * py;		/* 0 centre .. 2 corner */
-			vig = 1.0f - CRT_VIGNETTE * (r2 * 0.5f);
+			vig = 1.0f - vignette * (r2 * 0.5f);
 			if(vig < 0.0f) { vig = 0.0f; }
 			win->crt_verts[n].color.r = vig;
 			win->crt_verts[n].color.g = vig;
@@ -287,6 +294,7 @@ sdl_build_crt_mesh(Window_info *win, int w, int h)
 	}
 	win->crt_nidx = idx;
 	win->crt_curve_for = g_crt_curve;
+	win->crt_vig_for = g_crt_vignette;
 }
 
 /* (Re)create the offscreen targets + mask + mesh at the given logical size. */
@@ -1101,8 +1109,9 @@ sdl_render_crt(Window_info *win)
 	int	w = win->width_req;
 	int	h = win->main_height;
 
-	/* Rebuild the mesh if the curvature knob changed at runtime. */
-	if(win->crt_curve_for != g_crt_curve) {
+	/* Rebuild the mesh if the curvature or vignette knob changed at runtime. */
+	if((win->crt_curve_for != g_crt_curve) ||
+				(win->crt_vig_for != g_crt_vignette)) {
 		sdl_build_crt_mesh(win, w, h);
 		if(!win->crt_verts) {
 			return;


### PR DESCRIPTION
The CRT effect dimmed the picture even with curvature, mask, and blur all at 0, because corner darkening was a hardcoded CRT_VIGNETTE (0.28) baked into the curvature mesh with no way to reduce it.

Expose it as a config var following the g_crt_curve/g_crt_mask pattern: a "CRT Vignette 0-100" menu entry (key crtvignette), clamped 0-100, with the mesh rebuilt live when the knob changes. Default 5 is much subtler than the old baked-in value; 0 gives a flat, full-brightness CRT.