### PR TITLE
Add configurable config-menu colors (text + background)

### DIFF
--- a/gsplus/src/config.c
+++ b/gsplus/src/config.c
@@ -176,6 +176,8 @@ int	g_hblur = 0;		/* horizontal linear blur, 0-100 (0=off, sharp) */
 int	g_vblur = 0;		/* vertical linear blur, 0-100 (0=off, sharp) */
 int	g_hide_mouse = 1;	/* hide host cursor over the window / in fullscreen */
 char	*g_cfg_ssdir = "";	/* screenshot output dir ("" = current dir) */
+char	*g_cfg_menu_fg = "FFFFFF"; /* config menu text color, RRGGBB hex */
+char	*g_cfg_menu_bg = "1E2A56"; /* config menu background, RRGGBB hex */
 
 Cfg_menu g_cfg_disk_menu[] = {
 { "Disk Configuration", g_cfg_disk_menu, 0, 0, CFGTYPE_MENU },
@@ -398,6 +400,9 @@ Cfg_menu g_cfg_sdl_video_menu[] = {
 { "Vertical Blur 0-100", &g_vblur, "vblur", 0, CFGTYPE_INT },
 { "Hide Mouse Cursor,0,No,1,Yes", &g_hide_mouse, "hidemouse", 0, CFGTYPE_INT },
 { "Screenshot Directory", &g_cfg_ssdir, "ssdir", 0, CFGTYPE_STR },
+{ "", 0, 0, 0, 0 },
+{ "Menu Text Color (RRGGBB hex)", &g_cfg_menu_fg, "menutextcolor", 0, CFGTYPE_STR },
+{ "Menu Background (RRGGBB hex)", &g_cfg_menu_bg, "menubgcolor", 0, CFGTYPE_STR },
 { "", 0, 0, 0, 0 },
 { "Back to Video Settings", g_cfg_video_menu, 0, 0, CFGTYPE_MENU },
 { 0, 0, 0, 0, 0 },
@@ -1089,6 +1094,53 @@ cfg_file_update_ptr(char **strptr, const char *str, int need_update)
 		g_config_kegs_update_needed = 1;
 		printf("Set g_config_kegs_update_needed = 1\n");
 	}
+}
+
+/* Parse an "RRGGBB" hex color string (optional leading '#') into a 0xRRGGBB
+ * pixel value.  Returns defval if the string is empty or malformed. */
+int
+cfg_color_from_hex(const char *str, int defval)
+{
+	char	*endptr;
+	long	val;
+	int	len;
+
+	if(!str) {
+		return defval;
+	}
+	if(*str == '#') {
+		str++;
+	}
+	if(*str == 0) {
+		return defval;
+	}
+	val = strtol(str, &endptr, 16);
+	len = (int)(endptr - str);
+	if((*endptr != 0) || (len < 1) || (len > 6) || (val < 0)) {
+		return defval;
+	}
+	return (int)(val & 0x00ffffff);
+}
+
+/* Normalize a hex color string in place: strip '#', spaces and tabs, and
+ * uppercase the hex digits, so it always displays tidily. */
+void
+cfg_normalize_hex_color(char *str)
+{
+	int	c, in, out;
+
+	in = 0;
+	out = 0;
+	while((c = str[in++]) != 0) {
+		if((c == '#') || (c == ' ') || (c == '\t')) {
+			continue;
+		}
+		if((c >= 'a') && (c <= 'f')) {
+			c = c - 'a' + 'A';
+		}
+		str[out++] = c;
+	}
+	str[out] = 0;
 }
 
 void
@@ -4572,6 +4624,10 @@ cfg_edit_mode_key(int key)
 	len = (int)strlen(&g_cfg_edit_buf[0]);
 	if(key == 0x0d) {		// Return
 		// Try to accept the change
+		if((g_cfg_edit_ptr == (void *)&g_cfg_menu_fg) ||
+				(g_cfg_edit_ptr == (void *)&g_cfg_menu_bg)) {
+			cfg_normalize_hex_color(&g_cfg_edit_buf[0]);
+		}
 		new_str = kegs_malloc_str(&g_cfg_edit_buf[0]);
 		if(g_cfg_edit_type == CFGTYPE_STR) {
 			cfg_file_update_ptr(g_cfg_edit_ptr, new_str, 1);

--- a/gsplus/src/protos_base.h
+++ b/gsplus/src/protos_base.h
@@ -162,6 +162,8 @@ void config_vbl_update(int doit_3_persec);
 void cfg_file_update_rom(const char *str);
 void cfg_file_update_ptr(char **strptr, const char *str, int need_update);
 void cfg_int_update(int *iptr, int new_val);
+int cfg_color_from_hex(const char *str, int defval);
+void cfg_normalize_hex_color(char *str);
 void cfg_load_charrom(void);
 void config_load_roms(void);
 void config_parse_config_kegs_file(void);

--- a/gsplus/src/video.c
+++ b/gsplus/src/video.c
@@ -36,6 +36,8 @@ extern int g_line_ref_amt;
 
 extern word32 g_c034_val;
 extern int g_config_control_panel;
+extern char *g_cfg_menu_fg;
+extern char *g_cfg_menu_bg;
 extern int g_halt_sim;
 
 word32 g_slow_mem_changed[SLOW_MEM_CH_SIZE];
@@ -2809,6 +2811,7 @@ video_draw_a2_string(int line, const byte *bptr)
 	word32	*wptr;
 	word32	line_bytes;
 	int	start_line, pixels_per_line, offset;
+	int	bg_pixel, fg_pixel;
 	int	i;
 
 	start_line = line*8;
@@ -2817,10 +2820,12 @@ video_draw_a2_string(int line, const byte *bptr)
 					g_video_act_margin_left;
 	wptr = g_mainwin_kimage.wptr;
 	wptr += offset;
+	bg_pixel = cfg_color_from_hex(g_cfg_menu_bg, 0x001e2a56);
+	fg_pixel = cfg_color_from_hex(g_cfg_menu_fg, 0x00ffffff);
 	for(i = 0; i < 8; i++) {
 		line_bytes = ((start_line + i) << 16) | (40 << 8) | 0;
 		redraw_changed_string(bptr, line_bytes, -1L,
-			wptr, 0, 0x00ffffff, pixels_per_line, 1);
+			wptr, bg_pixel, fg_pixel, pixels_per_line, 1);
 	}
 	g_mainwin_kimage.x_refresh_needed = 1;
 }


### PR DESCRIPTION
Two new SDL Display Effects settings let the user set the config menu's text and background colors as RRGGBB hex strings, defaulting to white on dark blue (#1E2A56). Persisted in config.kegs as menutextcolor/menubgcolor.

- config.c: g_cfg_menu_fg/g_cfg_menu_bg globals, two CFGTYPE_STR menu entries at the bottom of the SDL effects menu, cfg_color_from_hex() parser, and cfg_normalize_hex_color() (strip #/spaces, uppercase) applied on edit-accept for the color fields only.
- video.c: video_draw_a2_string() renders the menu with the parsed colors instead of hardcoded white-on-black.
- protos_base.h: prototypes for the two helpers.