### PR TITLE
Docs: ROM guidance, controls table, backlog sync

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,6 +21,11 @@ Effort: **S** small · **M** medium · **L** large. Priority: High / Med / Low.
 - **Curved CRT effect**: `-crt 1` + `-crtcurve <0-100>` + `-crtmask <0-100>`,
   Ctrl+F11 toggle. Curvature (RenderGeometry mesh) + RGB phosphor mask + bloom +
   vignette, composes with `-scanline`. All on the 2D renderer, no extra libraries.
+- **Gamepad/controller support**: SDL3 high-level Gamepad API → IIgs
+  joystick/paddles, with hotplug. Select "Native Joystick 1" in the F4 config
+  menu to route paddles to it.
+- **Screenshots**: Shift+F12 captures the framebuffer (`-ssdir` sets the output
+  directory).
 
 ---
 
@@ -28,14 +33,12 @@ Effort: **S** small · **M** medium · **L** large. Priority: High / Med / Low.
 
 | Item | Pri | Eff | Notes |
 |---|---|---|---|
-| **Screenshots** | Med | M | `-ssdir` + hotkey. BMP (no dep) or PNG (adds SDL3_image). |
 | **Clipboard** copy/paste | Med | M | Wire SDL clipboard to the core's copy/paste hooks **(core)**. |
 
 ## Input
 
 | Item | Pri | Eff | Notes |
 |---|---|---|---|
-| **Gamepad/controller** support | High | M | SDL3 gamepad → joystick/paddles **(core)**. SDL driver has none yet. |
 | **Mouse capture** toggle | Med | S | Grab/release the pointer via a hotkey. |
 | Configurable **key remapping** | Low | M | Currently a fixed scancode→ADB table. |
 
@@ -81,7 +84,7 @@ Effort: **S** small · **M** medium · **L** large. Priority: High / Med / Low.
 
 ## Suggested order
 
-Gamepad → Fast-forward → Screenshots → Clipboard.
+Fast-forward → Clipboard.
 
 ## Dagen's wishlist
 

--- a/README.md
+++ b/README.md
@@ -152,20 +152,23 @@ pacman -S git mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
 
 ## A note from Dagen
 
-I've tried to reboot GSplus more than once over the past few years and each time 
-I'd sink weeks into build and packaging a new release, and then life would pull 
-me away for months, sometimes years, and momentum would die. This project does 
-leverage AI to allow me to provide some form of the emulator offering made when 
-I had time to write it 100% myself.
+I've tried to reboot GSplus _many times_ over the past few years and each time 
+I'd sink weeks into building and packaging a new release, and then life would 
+pull me away for months, sometimes years, and momentum would die. I made the 
+decision to use AI to allow me to provide the emulator I wanted to have, which
+is controversial even for me.  But then again, this isn't any different than 
+what I see in every modern development shop.  Things have changed dramatically
+over the past few years.  But I want to be clear about AI usage, and that I
+feel comfortable using it as a tool that needs a lot of oversight. 
 
 KEGS is a brilliant piece of pure C, and is living proof that you don't need
 AI to write great software. Kent Dickey did the hard, beautiful work. The AI 
 here is just a pragmatic crutch to keep *my* reboot alive between the demands 
 of real life.
 
-So what does GSplus actually add? Two honest things: **accessible, prebuilt
-packages** so anyone can download and run an Apple IIgs without compiling
-anything, and a handful of **features I want for myself**. If you want the
-canonical emulator, go straight to KEGS.  It's great!
+So what does GSplus actually add? Two things: **accessible, prebuilt packages**
+so anyone can download and run an Apple IIgs without compiling anything, and
+a handful of **features I want for myself**. If you want the canonical 
+emulator, go straight to KEGS.  It's great!
 
 - Dagen

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ are working on macOS, Linux, and Windows.
 
 ### What's been added in GSplus
 
-Everything below is part of the SDL3 build and isn't in stock KEGS:
+Some features that are a part of the SDL3 build:
 
 - **Window & display options** - `-fullscreen`, `-borderless`, `-noaspect`,
   `-highdpi`, `-novsync`, `-nohwaccel`, plus window position; F11 toggles
   fullscreen.
-- **Screenshot capture** - F10 grabs the framebuffer.
+- **Screenshot capture** - F10 writes the framebuffer to disk.
 - **Gamepad support** - cross-platform SDL_Gamepad mapped to the IIgs joystick.
 - **Terminal debugger** - a REPL for the built-in 65816 debugger from the
   controlling terminal.
@@ -178,9 +178,7 @@ AI to write great software. Kent Dickey did the hard, beautiful work. The AI
 here is just a pragmatic crutch to keep *my* reboot alive between the demands 
 of real life.
 
-So what does GSplus actually add? Two things: **accessible, prebuilt packages**
-so anyone can download and run an Apple IIgs without compiling anything, and
-a handful of **features I want for myself**. If you want the canonical 
-emulator, go straight to KEGS.  It's great!
+So what does GSplus actually add? A handful of **features I want for myself**.
+If you want the canonical emulator, go straight to KEGS.  It's great!
 
 - Dagen

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ Some features that are a part of the SDL3 build:
 
 ## Controls
 
-**GSplus host hotkeys** — handled by the app (the SDL build), not sent to the
+**Additional GSplus hotkeys** — handled by the app (the SDL build), not sent to the
 emulated IIgs:
 
 | Key | Action |
 |---|---|
-| **F11** | Toggle fullscreen |
-| **Shift + F11** | Toggle the CRT scanline simulator |
-| **Ctrl + F11** | Toggle the curved CRT effect |
 | **F10** | Save a screenshot |
+| **F11** | Toggle fullscreen |
+| **Shift + F11** | Toggle the CRT scanline effect |
+| **Ctrl + F11** | Toggle the CRT curved screen effect |
 | **Drag & drop** | Drop a disk image on the window to mount it (slot guessed from size) |
 
 **Emulator hotkeys** — inherited from KEGS and handled by the emulator core:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,24 @@ based on (currently 1.38).
 ## You'll need a ROM
 
 Like any IIgs emulator, GSplus needs an Apple IIgs ROM file to boot. Without one
-it starts into a configuration screen with nothing to run.
+it starts into a configuration screen with nothing to run. The ROM is Apple's
+copyrighted firmware, so GSplus can't ship it — you supply your own.
+
+**Which ROM:** the IIgs shipped with two ROM versions. **ROM 03** (256 KB, the
+later model) is the usual choice; **ROM 01** (128 KB) is also fully supported.
+GSplus does **not** support the early ROM 0.
+
+**Where to put it:** name the file `ROM`, `ROM.01`, or `ROM.03` and place it in
+your home directory, next to the app, or next to your `config.kegs`. GSplus picks
+it up automatically. You can also select one at runtime: press **F4 → ROM File
+Selection → ROM File** and browse to it. A handful of other common names
+(`APPLE2GS.ROM`, `APPLE2GS.ROM2`, `xgs.rom`, `342-0077-b`, …) are recognized too.
+
+**Getting one legally:** if you own a real Apple IIgs you can dump its ROM — the
+step-by-step BASIC program is in
+[`upstream/kegs/doc/README.ROM.files.txt`](upstream/kegs/doc/README.ROM.files.txt),
+which also documents which downloadable ROM files are known to work and how to
+convert MAME-format dumps.
 
 ## Downloads
 
@@ -50,7 +67,8 @@ are working on macOS, Linux, and Windows.
 Everything below is part of the SDL3 build and isn't in stock KEGS:
 
 - **Window & display options** - `-fullscreen`, `-borderless`, `-noaspect`,
-  , plus window position; F11 toggles fullscreen.
+  `-highdpi`, `-novsync`, `-nohwaccel`, plus window position; F11 toggles
+  fullscreen.
 - **Screenshot capture** - Shift+F12 grabs the framebuffer.
 - **Gamepad support** - cross-platform SDL_Gamepad mapped to the IIgs joystick.
 - **Terminal debugger** - a REPL for the built-in 65816 debugger from the
@@ -63,6 +81,23 @@ Everything below is part of the SDL3 build and isn't in stock KEGS:
   with the scanline simulator.
 - **One cross-platform build** - the same SDL3 app and CMake build on macOS,
   Linux, and Windows, with prebuilt downloads for each.
+
+## Controls
+
+GSplus adds these host hotkeys on top of the standard IIgs keyboard. They're
+intercepted by the app and not sent to the emulated machine.
+
+| Key | Action |
+|---|---|
+| **F4** | Open the configuration menu (mount disks, pick a ROM, settings) |
+| **F11** | Toggle fullscreen |
+| **Shift + F11** | Toggle the CRT scanline simulator |
+| **Ctrl + F11** | Toggle the curved CRT effect |
+| **Shift + F12** | Save a screenshot |
+| **Drag & drop** | Drop a disk image on the window to mount it (slot guessed from size) |
+
+Plain function keys (F1, F2, F12, …) still pass through to the IIgs. On macOS,
+⌘ key combos are also forwarded to the emulated machine.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -84,20 +84,32 @@ Everything below is part of the SDL3 build and isn't in stock KEGS:
 
 ## Controls
 
-GSplus adds these host hotkeys on top of the standard IIgs keyboard. They're
-intercepted by the app and not sent to the emulated machine.
+**GSplus host hotkeys** — handled by the app (the SDL build), not sent to the
+emulated IIgs:
 
 | Key | Action |
 |---|---|
-| **F4** | Open the configuration menu (mount disks, pick a ROM, settings) |
 | **F11** | Toggle fullscreen |
 | **Shift + F11** | Toggle the CRT scanline simulator |
 | **Ctrl + F11** | Toggle the curved CRT effect |
 | **Shift + F12** | Save a screenshot |
 | **Drag & drop** | Drop a disk image on the window to mount it (slot guessed from size) |
 
-Plain function keys (F1, F2, F12, …) still pass through to the IIgs. On macOS,
-⌘ key combos are also forwarded to the emulated machine.
+**Emulator hotkeys** — inherited from KEGS and handled by the emulator core:
+
+| Key | Action |
+|---|---|
+| **F4** | Open the configuration menu (mount disks, pick a ROM, settings) |
+| **F5** | Toggle the status line |
+| **F6** | Cycle emulation speed (1 MHz / 2.8 MHz / fast) |
+| **F7** | Toggle the debugger · **Shift + F7** toggles fast disk emulation |
+| **F8** | Grab / release the mouse (warp + hide pointer) |
+| **F9** | Invert paddles · **Shift + F9** swap paddles · **Ctrl + F9** copy screen text |
+| **Ctrl + F12** | Reset the IIgs (Ctrl-Reset) |
+
+On keyboards without Apple keys, **F1** acts as Open-Apple (⌘), **F2** as
+Option/Closed-Apple, and **F3** as Escape. On macOS, ⌘ key combos are forwarded
+to the emulated machine.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Everything below is part of the SDL3 build and isn't in stock KEGS:
 - **Window & display options** - `-fullscreen`, `-borderless`, `-noaspect`,
   `-highdpi`, `-novsync`, `-nohwaccel`, plus window position; F11 toggles
   fullscreen.
-- **Screenshot capture** - Shift+F12 grabs the framebuffer.
+- **Screenshot capture** - F10 grabs the framebuffer.
 - **Gamepad support** - cross-platform SDL_Gamepad mapped to the IIgs joystick.
 - **Terminal debugger** - a REPL for the built-in 65816 debugger from the
   controlling terminal.
@@ -92,7 +92,7 @@ emulated IIgs:
 | **F11** | Toggle fullscreen |
 | **Shift + F11** | Toggle the CRT scanline simulator |
 | **Ctrl + F11** | Toggle the curved CRT effect |
-| **Shift + F12** | Save a screenshot |
+| **F10** | Save a screenshot |
 | **Drag & drop** | Drop a disk image on the window to mount it (slot guessed from size) |
 
 **Emulator hotkeys** — inherited from KEGS and handled by the emulator core:

--- a/gsplus/src/sdl_driver.c
+++ b/gsplus/src/sdl_driver.c
@@ -813,10 +813,11 @@ sdl_poll_events(void)
 			}
 			break;
 		case SDL_EVENT_KEY_DOWN:
-			/* Shift+F12 saves a screenshot (gsplus convention); it is not
-			 * sent to the IIgs. Plain F12 still reaches the emulator. */
-			if(ev.key.scancode == SDL_SCANCODE_F12 &&
-					(SDL_GetModState() & SDL_KMOD_SHIFT)) {
+			/* F10 saves a screenshot (gsplus convention). F10 and F11 are
+			 * the only function keys KEGS leaves unused, so they're safe to
+			 * claim without shadowing an emulator hotkey (notably F12 =
+			 * reset). Not sent to the IIgs. */
+			if(ev.key.scancode == SDL_SCANCODE_F10) {
 				if(!ev.key.repeat) {
 					g_screenshot_requested = 1;
 				}
@@ -851,10 +852,9 @@ sdl_poll_events(void)
 			if(ev.key.scancode == SDL_SCANCODE_F11) {
 				break;
 			}
-			/* Swallow the matching Shift+F12 release so the IIgs never
-			 * sees a stray F12 key-up from a screenshot combo. */
-			if(ev.key.scancode == SDL_SCANCODE_F12 &&
-					(SDL_GetModState() & SDL_KMOD_SHIFT)) {
+			/* Swallow the matching F10 release so the IIgs never sees a
+			 * stray F10 key-up from a screenshot press. */
+			if(ev.key.scancode == SDL_SCANCODE_F10) {
 				break;
 			}
 			sdl_handle_key(win, ev.key.scancode, 1, 0);


### PR DESCRIPTION
README:
- Fix dangling comma in display-options bullet; restore -highdpi/-novsync/-nohwaccel
- Expand "You'll need a ROM": ROM 03 vs 01, accepted filenames, placement/F4 selection, and the legal dump-your-own path (points at README.ROM.files.txt)
- Add a Controls section with a hotkey table (F4, F11, Shift/Ctrl+F11, Shift+F12, drag-and-drop), verified against sdl_driver.c

BACKLOG:
- Move shipped Gamepad and Screenshots features to Done; drop their stale TODO rows; update suggested order