### PR TITLE
CI: derive release prerelease/Latest from the tag name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,5 +153,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: artifacts/**/*
-          prerelease: true
+          # Derive the release flags from the tag name: a plain version tag
+          # (v1.38.0) is a full release and becomes "Latest"; a pre-release tag
+          # carrying a suffix (v1.38.0-beta1, -alpha0, -rc1) stays a pre-release
+          # and is never marked Latest.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}
           generate_release_notes: true


### PR DESCRIPTION
The release job hardcoded prerelease: true, so even a full version tag like v1.38.0 published as a pre-release with no "Latest" badge. Derive both flags from the tag name instead: a plain tag (v1.38.0) is a full release and is set as Latest; a suffixed tag (v1.38.0-beta1, -alpha0, -rc1) stays a pre-release and is never marked Latest.