### PR TITLE
Add native arm64 Linux build to CI releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,19 @@ jobs:
           path: build/*.dmg
 
   linux:
-    runs-on: ubuntu-latest
+    # One build per CPU architecture. ubuntu-24.04-arm is a native arm64 runner
+    # (free for public repos), so the ARM build needs no cross-compiling — the
+    # identical steps just run on ARM hardware. CPack stamps the architecture
+    # into the tarball name (Linux-x86_64 / Linux-aarch64) so the two release
+    # assets don't collide.
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - name: Install tools + SDL3 build deps
@@ -101,7 +113,7 @@ jobs:
         run: cd build && cpack
       - uses: actions/upload-artifact@v4
         with:
-          name: gsplus-linux
+          name: gsplus-linux-${{ matrix.arch }}
           path: build/*.tar.gz
 
   windows:

--- a/gsplus/src/CMakeLists.txt
+++ b/gsplus/src/CMakeLists.txt
@@ -393,6 +393,9 @@ else()
         # On Linux the SDL3 .so is bundled by the AppImage step in CI; a plain
         # TGZ relies on the system SDL3.
         set(CPACK_GENERATOR "TGZ")
+        # Put the CPU architecture in the archive name (GSplus-x.y.z-Linux-x86_64
+        # vs -Linux-aarch64) so the two Linux release assets don't collide.
+        set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
     endif()
     # No top-level "<name>-<version>" wrapper dir -- put files at the archive root.
     set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)


### PR DESCRIPTION
The Linux release tarball was x86_64-only, failing with "Exec format error" on ARM Linux. Turn the linux CI job into a matrix over ubuntu-latest and ubuntu-24.04-arm (GitHub's native arm64 runner), and stamp the CPU architecture into the CPack tarball name (Linux-x86_64 / Linux-aarch64) so the two release assets don't collide.