### PR TITLE
Ship README and LICENSE in every release artifact

### DIFF
--- a/gsplus/src/CMakeLists.txt
+++ b/gsplus/src/CMakeLists.txt
@@ -391,7 +391,9 @@ else()
         set(CPACK_GENERATOR "ZIP")            # CI can upgrade to an NSIS installer
     else()
         # On Linux the SDL3 .so is bundled by the AppImage step in CI; a plain
-        # TGZ relies on the system SDL3.
+        # TGZ relies on the system SDL3 -- README-linux.txt tells the user how
+        # to install it (distro package or build from source).
+        install(FILES packaging/README-linux.txt DESTINATION .)
         set(CPACK_GENERATOR "TGZ")
         # Put the CPU architecture in the archive name (GSplus-x.y.z-Linux-x86_64
         # vs -Linux-aarch64) so the two Linux release assets don't collide.
@@ -400,6 +402,13 @@ else()
     # No top-level "<name>-<version>" wrapper dir -- put files at the archive root.
     set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
 endif()
+
+# Every artifact ships the project README and the GPL license text (the GPL
+# requires the license to accompany distributed binaries). These paths are
+# relative to gsplus/src, so ../.. is the repository root.
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../../README.md"
+              "${CMAKE_CURRENT_SOURCE_DIR}/../../LICENSE"
+        DESTINATION .)
 
 set(CPACK_PACKAGE_NAME "GSplus")
 set(CPACK_PACKAGE_VENDOR "GSplus Contributors")

--- a/gsplus/src/packaging/README-linux.txt
+++ b/gsplus/src/packaging/README-linux.txt
@@ -1,0 +1,41 @@
+GSplus on Linux
+===============
+
+GSplus needs the SDL3 library installed on your system. If launching
+fails with an error like:
+
+    error while loading shared libraries: libSDL3.so.0:
+    cannot open shared object file: No such file or directory
+
+install SDL3 for your distribution:
+
+  Debian 13 "trixie" or newer, Ubuntu 25.04 or newer:
+      sudo apt install libsdl3-0
+
+  Fedora:
+      sudo dnf install SDL3
+
+  Arch:
+      sudo pacman -S sdl3
+
+Older releases (Debian 12, Ubuntu 24.04 LTS, and earlier) do not package
+SDL3 at all -- build it from source:
+
+    # Dev packages SDL needs for video/audio support; see
+    # https://wiki.libsdl.org/SDL3/README-linux for the full list.
+    sudo apt install build-essential cmake git \
+        libx11-dev libxext-dev libwayland-dev libxkbcommon-dev \
+        libegl1-mesa-dev libpulse-dev libasound2-dev
+
+    git clone https://github.com/libsdl-org/SDL
+    cmake -S SDL -B SDL/build -DCMAKE_BUILD_TYPE=Release
+    cmake --build SDL/build -j$(nproc)
+    sudo cmake --install SDL/build
+    sudo ldconfig
+
+Running
+-------
+
+GSplus also needs an Apple IIgs ROM file and a config file to be useful.
+See README.md (included alongside this file) for setup instructions,
+hotkeys, and everything else.


### PR DESCRIPTION
Every package (dmg, tar.gz, zip) now includes the project README and the GPL license text, which the GPL requires to accompany distributed binaries. The Linux tarballs additionally get README-linux.txt with instructions for installing libSDL3.so.0 (packaged only on Debian 13 "trixie"+ / Ubuntu 25.04+; older distros must build SDL3 from source).