### PR TITLE
List the display option flags in the CLI help

### DIFF
--- a/gsplus/src/config.c
+++ b/gsplus/src/config.c
@@ -583,6 +583,31 @@ int	g_menu_redraw_needed = 1;
 int g_cfg_argv_num_overrides = 0;
 char *g_cfg_argv_overrides[MAX_CFG_ARGV_OVERRIDES];
 
+/* Print the GSplus display-effect config variables as CLI flags, for
+ *  print_usage().  Driven by the menu table so the help text can't drift
+ *  from the actual options: every entry with a config-file name is listed,
+ *  using its menu label (the part of str before the value list). */
+void
+cfg_print_cli_flags()
+{
+	Cfg_menu *menuptr;
+	const char *str;
+	int	i, len;
+
+	menuptr = &g_cfg_sdl_video_menu[0];
+	for(i = 0; menuptr[i].str != 0; i++) {
+		if(!menuptr[i].name_str) {
+			continue;	/* menu title, separator or Back row */
+		}
+		str = menuptr[i].str;
+		len = 0;
+		while(str[len] && (str[len] != ',')) {
+			len++;
+		}
+		printf("  -%-14s  %.*s\n", menuptr[i].name_str, len, str);
+	}
+}
+
 int
 config_add_argv_override(const char *str1, const char *str2)
 {

--- a/gsplus/src/protos_base.h
+++ b/gsplus/src/protos_base.h
@@ -142,6 +142,7 @@ void do_clock_data(void);
 
 /* config.c */
 int config_add_argv_override(const char *str1, const char *str2);
+void cfg_print_cli_flags(void);
 void config_set_config_kegs_name(const char *str1);
 void config_init_menus(Cfg_menu *menuptr);
 void config_init(void);

--- a/gsplus/src/sim65816.c
+++ b/gsplus/src/sim65816.c
@@ -521,6 +521,10 @@ print_usage(const char *argv0)
 	printf("  -cfg <file>      Use <file> as the config file "
 						"(created if absent)\n");
 	printf("\n");
+	printf("Display options (config variables, override with "
+						"-<name> <value>):\n");
+	cfg_print_cli_flags();
+	printf("\n");
 	printf("Any other -<name> <value> is applied as a config variable "
 							"override.\n");
 }


### PR DESCRIPTION
-h only mentioned the display options via the generic "any other -<name> <value> is a config variable override" line, so flags like -centera2 and -crtglow were undiscoverable. Add cfg_print_cli_flags(), which walks the Display Effects menu table and prints every entry that has a config-file name using its menu label, and call it from print_usage(). Being table-driven, the help picks up future options added to that menu automatically.


Claude-Session: https://claude.ai/code/session_012YhTRt358eMKiNLiDXVDAB